### PR TITLE
Bounds checking and generic headers

### DIFF
--- a/uwsgi.go
+++ b/uwsgi.go
@@ -145,6 +145,7 @@ func (l *Listener) Accept() (net.Conn, error) {
 
 	envbuf := make([]byte, envsize)
 	if _, err := io.ReadFull(fd, envbuf); err != nil {
+		fd.Close()
 		return nil, err
 	}
 


### PR DESCRIPTION
I've experienced panic from nginx for unknown reasons (didn't have a core dump to investigate further). But could be due to corrupt/invalid input.

I've now coded up bounds checking of key-value vars. Also included are generic header support, upper case header mappings, and enable repeated headers (sometimes they exist).

Please have a look and see if you want to merge back to trunk after testing.
Thanks
Leon
