### PR TITLE
Improve accept() throughput and fix connection blockade due to accepting Connection and SERVER_PROTOCOL headers.

### DIFF
--- a/uwsgi.go
+++ b/uwsgi.go
@@ -32,59 +32,100 @@ type Listener struct {
 }
 
 type Conn struct {
-	env    map[string] []string
-	reader io.Reader
-	writer net.Conn
+	env     map[string] []string
+	reader  io.Reader
+	conn    net.Conn
+	hdrdone bool
+	ready   bool
+	readych chan bool
+	err     error
 }
 
-func (c *Conn) Read(b []byte) (int, error) {
-	n, e := c.reader.Read(b)
+func (c *Conn) Read(b []byte) (n int, e error) {
+	// Wait until headers have been processed
+	if !c.ready && c.err == nil {
+		<-c.readych
+		c.ready = true
+	}
+	if c.err != nil {
+		return 0, c.err
+	}
+
+	// After headers have been read by HTTP server, transfer
+	// socket over to the underlying connection for direct read.
+	if !c.hdrdone {
+		n, e = c.reader.Read(b)
+		if n == 0 || e != nil {
+			c.hdrdone = true
+		}
+	}
+	if c.hdrdone {
+		n, e = c.conn.Read(b)
+		c.err = e
+	}
+
 	return n, e
 }
 
 func (c *Conn) Write(b []byte) (int, error) {
-	return c.writer.Write(b)
+	if c.err != nil {
+		return 0, c.err
+	}
+
+	return c.conn.Write(b)
 }
 
 func (c *Conn) Close() error {
-	return c.writer.Close()
+	return c.conn.Close()
 }
 
 func (c *Conn) LocalAddr() net.Addr {
-	return c.writer.LocalAddr()
+	return c.conn.LocalAddr()
 }
 
 func (c *Conn) RemoteAddr() net.Addr {
-	return c.writer.RemoteAddr()
+	return c.conn.RemoteAddr()
 }
 
 func (c *Conn) SetDeadline(t time.Time) error {
-	return c.writer.SetDeadline(t)
+	if c.err != nil {
+		return c.err
+	}
+
+	return c.conn.SetDeadline(t)
 }
 
 func (c *Conn) SetReadDeadline(t time.Time) error {
-	return c.writer.SetReadDeadline(t)
+	if c.err != nil {
+		return c.err
+	}
+
+	return c.conn.SetReadDeadline(t)
 }
 
 func (c *Conn) SetWriteDeadline(t time.Time) error {
-	return c.writer.SetWriteDeadline(t)
+	if c.err != nil {
+		return c.err
+	}
+
+	return c.conn.SetWriteDeadline(t)
 }
 
 /*
 func (c *Conn) SetTimeout(s int64) error {
-	return c.writer.SetTimeout(s)
+	return c.conn.SetTimeout(s)
 }
 */
 
 /*
 func (c *Conn) SetReadTimeout(s int64) error {
-	return c.writer.SetReadTimeout(s)
+	return c.conn.SetReadTimeout(s)
 }
 */
 
 /*
 func (c *Conn) SetWriteTimeout(s int64) error {
-	return c.writer.SetWriteTimeout(s)
+	return c.conn.SetWriteTimeout(s)
 }
 */
 
@@ -105,7 +146,7 @@ var headerMappings = map[string]string{
 	"HTTP_ACCEPT_CHARSET": "Accept-Charset",
 	"HTTP_CONTENT_TYPE": "Content-Type",
 	"HTTP_COOKIE": "Cookie",
-	"HTTP_CONNECTION" : "Connection",
+	// "HTTP_CONNECTION" : "Connection",
 	"HTTP_IF_MATCH": "If-Match",
 	"HTTP_IF_MODIFIED_SINCE": "If-Modified-Since",
 	"HTTP_IF_NONE_MATCH": "If-None-Match",
@@ -125,132 +166,141 @@ func (l *Listener) Accept() (net.Conn, error) {
 	}
 
 	buf := new(bytes.Buffer)
-	c := &Conn{make(map[string] []string), buf, fd}
+	c := &Conn{make(map[string] []string), buf, fd, false, false, make(chan bool, 1), nil}
 
-	/*
-	 * uwsgi header:
-	 * struct {
-	 *    uint8  modifier1;
-	 *    uint16 datasize;
-	 *    uint8  modifier2;
-	 * }
-	 *  -- for HTTP, mod1 and mod2 = 0
-	 */
-	var head [4]byte
-	fd.Read(head[:])
-	//mod1 := head[0:0]
-	b := []byte{head[1], head[2]}
-	envsize := binary.LittleEndian.Uint16(b)
-	//mod2 := head[3:3]
+	go func() {
+		/*
+		 * uwsgi header:
+		 * struct {
+		 *    uint8  modifier1;
+		 *    uint16 datasize;
+		 *    uint8  modifier2;
+		 * }
+		 *  -- for HTTP, mod1 and mod2 = 0
+		 */
+		var head [4]byte
+		fd.Read(head[:])
+		//mod1 := head[0:0]
+		b := []byte{head[1], head[2]}
+		envsize := binary.LittleEndian.Uint16(b)
+		//mod2 := head[3:3]
 
-	envbuf := make([]byte, envsize)
-	if _, err := io.ReadFull(fd, envbuf); err != nil {
-		fd.Close()
-		return nil, err
-	}
-
-	/*
-	 * uwsgi vars are linear lists of the form:
-	 * struct {
-	 *   uint16 key_size;
-	 *   uint8  key[key_size];
-	 *   uint16 val_size;
-	 *   uint8  val[val_size];
-	 * }
-	 */
-	i := uint16(0)
-	var reqMethod string
-	var reqUri string
-	var reqProtocol string
-	for {
-		// Ensure no corrupted payload; shouldn't happen but it has...
-		if i+1 >= uint16(len(envbuf)) {
-			break
-		}
-		b := []byte{envbuf[i], envbuf[i+1]}
-		kl := binary.LittleEndian.Uint16(b)
-		i += 2
-
-		if i+kl > uint16(len(envbuf)) {
+		envbuf := make([]byte, envsize)
+		if _, err := io.ReadFull(fd, envbuf); err != nil {
 			fd.Close()
-			return nil, errors.New("Invalid uwsgi request; uwsgi vars index out of range")
+			c.err = err
+			return
 		}
 
-		k := string(envbuf[i : i+kl])
-		i += kl
-
-		if i+1 >= uint16(len(envbuf)) {
-			fd.Close()
-			return nil, errors.New("Invalid uwsgi request; uwsgi vars index out of range")
-		}
-
-		b = []byte{envbuf[i], envbuf[i+1]}
-		vl := binary.LittleEndian.Uint16(b)
-		i += 2
-
-		if i+vl > uint16(len(envbuf)) {
-			fd.Close()
-			return nil, errors.New("Invalid uwsgi request; uwsgi vars index out of range")
-		}
-
-		v := string(envbuf[i : i+vl])
-		i += vl
-
-		if k == "REQUEST_METHOD" {
-			reqMethod = v
-		} else if k == "REQUEST_URI" {
-			reqUri = v
-		} else if k == "SERVER_PROTOCOL" {
-			reqProtocol = v
-		}
-
-		val, ok := c.env[k]
-		if !ok {
-			val = make([]string, 0, 2)
-		}
-		val = append(val, v)
-		c.env[k] = val
-
-		if i >= envsize {
-			break
-		}
-	}
-
-	if reqProtocol == "" {
-		// Invalid protocol
-		fd.Close()
-		return nil, errors.New("Invalid uwsgi request; no protocol specified")
-	}
-	reqProtocol="HTTP/1.0"
-
-
-	//fmt.Fprintf(buf, "%s %s %s\r\n", c.env["REQUEST_METHOD"], c.env["REQUEST_URI"], c.env["SERVER_PROTOCOL"])
-	fmt.Fprintf(buf, "%s %s %s\r\n", reqMethod, reqUri, reqProtocol)
-
-	var cl int64
-	for i := range c.env {
-		switch i {
-		case "CONTENT_LENGTH":
-			cl, _ = strconv.ParseInt(c.env[i][0], 10, 64)
-			if cl > 0 {
-				fmt.Fprintf(buf, "Content-Length: %d\r\n", cl)
+		/*
+		 * uwsgi vars are linear lists of the form:
+		 * struct {
+		 *   uint16 key_size;
+		 *   uint8  key[key_size];
+		 *   uint16 val_size;
+		 *   uint8  val[val_size];
+		 * }
+		 */
+		i := uint16(0)
+		var reqMethod string
+		var reqUri string
+		var reqProtocol string
+		for {
+			// Ensure no corrupted payload; shouldn't happen but it has...
+			if i+1 >= uint16(len(envbuf)) {
+				break
 			}
-		default:
-			hname, ok := headerMappings[i]
+			b := []byte{envbuf[i], envbuf[i+1]}
+			kl := binary.LittleEndian.Uint16(b)
+			i += 2
+
+			if i+kl > uint16(len(envbuf)) {
+				fd.Close()
+				c.err = errors.New("Invalid uwsgi request; uwsgi vars index out of range")
+				return
+			}
+
+			k := string(envbuf[i : i+kl])
+			i += kl
+
+			if i+1 >= uint16(len(envbuf)) {
+				fd.Close()
+				c.err = errors.New("Invalid uwsgi request; uwsgi vars index out of range")
+				return
+			}
+
+			b = []byte{envbuf[i], envbuf[i+1]}
+			vl := binary.LittleEndian.Uint16(b)
+			i += 2
+
+			if i+vl > uint16(len(envbuf)) {
+				fd.Close()
+				c.err = errors.New("Invalid uwsgi request; uwsgi vars index out of range")
+				return
+			}
+
+			v := string(envbuf[i : i+vl])
+			i += vl
+
+			if k == "REQUEST_METHOD" {
+				reqMethod = v
+			} else if k == "REQUEST_URI" {
+				reqUri = v
+			} else if k == "SERVER_PROTOCOL" {
+				// Ignore protocol; set to 1.0 so that it disconnects from server
+				v = "HTTP/1.0"
+				reqProtocol = v
+			}
+
+			val, ok := c.env[k]
 			if !ok {
-				hname = i
+				val = make([]string, 0, 2)
 			}
-			for v := range c.env[i] {
-				fmt.Fprintf(buf, "%s: %s\r\n", hname, c.env[i][v])
+			val = append(val, v)
+			c.env[k] = val
+
+			if i >= envsize {
+				break
 			}
 		}
-	}
 
-	buf.Write([]byte("\r\n"))
+		if reqProtocol == "" {
+			// Invalid protocol
+			fd.Close()
+			c.err = errors.New("Invalid uwsgi request; no protocol specified")
+			return
+		}
+		reqProtocol="HTTP/1.0"
 
-	if cl > 0 {
-		io.CopyN(buf, fd, cl)
-	}
+
+		//fmt.Fprintf(buf, "%s %s %s\r\n", c.env["REQUEST_METHOD"], c.env["REQUEST_URI"], c.env["SERVER_PROTOCOL"])
+		fmt.Fprintf(buf, "%s %s %s\r\n", reqMethod, reqUri, reqProtocol)
+
+		var cl int64
+		for i := range c.env {
+			switch i {
+			case "CONTENT_LENGTH":
+				cl, _ = strconv.ParseInt(c.env[i][0], 10, 64)
+				if cl > 0 {
+					fmt.Fprintf(buf, "Content-Length: %d\r\n", cl)
+				}
+			default:
+				hname, ok := headerMappings[i]
+				if !ok {
+					hname = i
+				}
+				for v := range c.env[i] {
+					fmt.Fprintf(buf, "%s: %s\r\n", hname, c.env[i][v])
+				}
+			}
+		}
+
+		buf.Write([]byte("\r\n"))
+
+		// Signal to indicate header processing is complete and remaining
+		// payload can be read from the socket itself.
+		c.readych <- true
+	}()
 
 	return c, nil
 }


### PR DESCRIPTION
Process requests within a goroutine after Accept() to allow new connections to come through; such is the case where there is a large POST request which could clog the connection listen queue.

Also force disconnection after processing one client connection by ignoring Connection and SERVER_PROTOCOL headers.

The other thing I've added is to not read the request body into the buffer, since it could be a big payload. Rather, after the headers have been completed, the Read() will transfer to the connection's socket. This eliminates the need to buffer multiple times.
