### PR TITLE
Fix for occassional 400 - too many headers

### DIFF
--- a/uwsgi.go
+++ b/uwsgi.go
@@ -247,6 +247,10 @@ func (l *Listener) Accept() (net.Conn, error) {
 			default:
 				hname, ok := headerMappings[i]
 				if !ok {
+					// To avoid double Host headers in some cases, only parse HTTP_HOST as a correct Host.
+					if i == "Host" {
+						continue
+					}
 					hname = i
 				}
 				for v := range c.env[i] {


### PR DESCRIPTION
When request contains `Host:` header (which can happen e.g. when offloading request through internal uwsgi routing), we will end up with two Host headers (another from HTTP_HOST uwsgi var). Which in Golang http server results in an error when using HTTP/1.1.

https://github.com/golang/go/blob/release-branch.go1.8/src/net/http/server.go#L954