### PR TITLE
Reverted forcing HTTP/1.0

### DIFF
--- a/uwsgi.go
+++ b/uwsgi.go
@@ -212,6 +212,7 @@ func (l *Listener) Accept() (net.Conn, error) {
 			} else if k == "REQUEST_URI" {
 				reqURI = v
 			} else if k == "SERVER_PROTOCOL" {
+				v = "HTTP/1.0"
 				reqProtocol = v
 			}
 


### PR DESCRIPTION
It seems that after all uwsgi is still expecting unchunked transfer specific to 1.0 and outputs 1.1 chunks in a raw format. Only when there is only 1 chunk it works fine.
As such, reverted these changes from: https://github.com/mattn/go-uwsgi/commit/c26fb9b6841b2a471935f391da27c89f5d870b9d

Sorry about the confusion. Only recently I actually started using this more extensively and missed it when tested before. 